### PR TITLE
Support text/html outputs too

### DIFF
--- a/src/renders.ts
+++ b/src/renders.ts
@@ -184,6 +184,7 @@ export const rendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
   mimeTypes: [
     'text/plain',
+    'text/html',
     'application/vnd.jupyter.stdout',
     'application/vnd.jupyter.stderr',
   ],


### PR DESCRIPTION
[xeus-sql](https://github.com/jupyter-xeus/xeus-sql) produces `text/html` output,
and that crashes the browser if users forget a `WHERE` clause. This PR makes
the extension limit HTML output as well.

This might break in weird ways as 'pagination' doesn't quite work the same
with HTML. Perhaps something to be hidden behind an option?