### PR TITLE
Dispose contents of node to contain memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.1](https://github.com/deshaw/jupyterlab-limit-output/compare/v1.0.0...v1.0.1) (2023-03-27)
+
+### Fixed
+
+- Fixed memory leak [#3](https://github.com/deshaw/jupyterlab-limit-output/issues/3)
+
 ## [1.0.0](https://github.com/deshaw/jupyterlab-limit-output/compare/v1.0.0...v1.0.0) (2022-02-18)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-limit-output",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Limit output text mime-renders",
   "keywords": [
     "jupyter",

--- a/src/renders.ts
+++ b/src/renders.ts
@@ -178,6 +178,19 @@ export class MyRenderedText extends RenderedText {
       translator: this.translator,
     });
   }
+
+  /**
+   * Dispose the contents of node to contain potential memory leak.
+   *
+   * **Notes**: when user attempts to clean the output using context menu
+   * they invoke `JupyterFrontEnd.evtContextMenu` which caches the event
+   * to enable commands and extensions to access it later; this leads to
+   * a memory leak as the the event holds the target node reference.
+   */
+  dispose() {
+    this.node.replaceChildren();
+    super.dispose();
+  }
 }
 
 export const rendererFactory: IRenderMime.IRendererFactory = {

--- a/src/renders.ts
+++ b/src/renders.ts
@@ -185,10 +185,10 @@ export class MyRenderedText extends RenderedText {
    * **Notes**: when user attempts to clean the output using context menu
    * they invoke `JupyterFrontEnd.evtContextMenu` which caches the event
    * to enable commands and extensions to access it later; this leads to
-   * a memory leak as the the event holds the target node reference.
+   * a memory leak as the event holds the target node reference.
    */
   dispose() {
-    this.node.replaceChildren();
+    this.node.innerHTML = '';
     super.dispose();
   }
 }

--- a/src/renders.ts
+++ b/src/renders.ts
@@ -189,6 +189,7 @@ export class MyRenderedText extends RenderedText {
    */
   dispose(): void {
     // TODO: remove ts-ignore during JupyterLab 4.0/TypeScript 5.0 migration
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.node.replaceChildren();
     super.dispose();

--- a/src/renders.ts
+++ b/src/renders.ts
@@ -187,8 +187,10 @@ export class MyRenderedText extends RenderedText {
    * to enable commands and extensions to access it later; this leads to
    * a memory leak as the event holds the target node reference.
    */
-  dispose() {
-    this.node.innerHTML = '';
+  dispose(): void {
+    // TODO: remove ts-ignore during JupyterLab 4.0/TypeScript 5.0 migration
+    // @ts-ignore
+    this.node.replaceChildren();
     super.dispose();
   }
 }


### PR DESCRIPTION
This is fix alleviating memory leak discussed in https://github.com/deshaw/jupyterlab-limit-output/issues/3#issuecomment-1465280675 and I believe it closes https://github.com/deshaw/jupyterlab-limit-output/issues/3 as I did not see other memory leaks post clearing outputs (although memory allocation during rendering could be substantially reduced).

A proper solution is implemented upstream in https://github.com/jupyterlab/jupyterlab/pull/14173.

| Before | After |
|----|----|
| ![Screenshot from 2023-03-12 19-28-51](https://user-images.githubusercontent.com/5832902/224571057-5adcacef-7514-4a33-88f9-f12968ec2594.png) | ![Screenshot from 2023-03-12 19-28-57](https://user-images.githubusercontent.com/5832902/224571063-e75a5580-0aa8-4dec-b84d-b0905e690c4c.png) |